### PR TITLE
Update rstudio dockerfile

### DIFF
--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -10,8 +10,8 @@ RUN apt-get update \
     && apt-get -y install \
         libffi-dev \
         libglpk-dev \
-        python3-pip \
-        python3.10-venv \
+#        python3-pip \
+#       python3.10-venv \
         rsync \
         zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
@@ -35,15 +35,23 @@ RUN /usr/local/lib/R/site-library/littler/examples/installBioc.r \
     org.Hs.eg.db \
     pathview
 
-# Install synapser using `install.packages()` (error when installed with install2.r)
-RUN R -e "install.packages('synapser', repos=c('http://ran.synapse.org', 'http://cran.fhcrc.org'))"
+# Install miniconda (required by synasper)
+ENV CONDA_DIR /opt/conda
+RUN wget --quiet \
+    https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+    -O ~/miniconda.sh && \
+    /bin/bash ~/miniconda.sh -b -p /opt/conda
+ENV PATH=$CONDA_DIR/bin:$PATH
 
 # Install Python dependencies
-RUN pip3 install \
+RUN pip install \
     pandas \
     requests \
     rpy2 \
     synapseclient
+
+# Install synapser using `install.packages()` (error when installed with install2.r)
+RUN R -e "install.packages('synapser', repos=c('http://ran.synapse.org', 'http://cran.fhcrc.org'))"
 
 COPY config/Rprofile.site /usr/local/lib/R/etc/
 COPY config/rserver.conf /etc/rstudio/rserver.conf

--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -10,8 +10,6 @@ RUN apt-get update \
     && apt-get -y install \
         libffi-dev \
         libglpk-dev \
-#        python3-pip \
-#       python3.10-venv \
         rsync \
         zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*

--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -1,5 +1,5 @@
 # rocker/tidyverse was built on rocker/rstudio (so, it includes RStudio)
-FROM rocker/tidyverse:4.1.0
+FROM rocker/tidyverse:4.2.2
 
 # Install OS-level dependencies
 # rsync needed for `broadcast_*` scripts
@@ -11,6 +11,7 @@ RUN apt-get update \
         libffi-dev \
         libglpk-dev \
         python3-pip \
+        python3.10-venv \
         rsync \
         zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
@@ -34,8 +35,8 @@ RUN /usr/local/lib/R/site-library/littler/examples/installBioc.r \
     org.Hs.eg.db \
     pathview
 
-# Install synapser using `install.packages()` (error when installed with install2.r)
-RUN R -e "install.packages('synapser', repos=c('http://ran.synapse.org', 'http://cran.fhcrc.org'))"
+# Install synapser directly from source
+RUN R -e "remotes::install_github(repo='https://github.com/generalui/synapser/tree/reticulate', ref='reticulate')"
 
 # Install Python dependencies
 RUN pip3 install \

--- a/rstudio/Dockerfile
+++ b/rstudio/Dockerfile
@@ -35,8 +35,8 @@ RUN /usr/local/lib/R/site-library/littler/examples/installBioc.r \
     org.Hs.eg.db \
     pathview
 
-# Install synapser directly from source
-RUN R -e "remotes::install_github(repo='https://github.com/generalui/synapser/tree/reticulate', ref='reticulate')"
+# Install synapser using `install.packages()` (error when installed with install2.r)
+RUN R -e "install.packages('synapser', repos=c('http://ran.synapse.org', 'http://cran.fhcrc.org'))"
 
 # Install Python dependencies
 RUN pip3 install \

--- a/rstudio/utils/add_users.sh
+++ b/rstudio/utils/add_users.sh
@@ -15,7 +15,7 @@ while read line; do
     userpass="${a[1]}"
     groupstr=$(join_by , "${b[@]}")
     echo "Adding user $user to groups $groupstr"
-    useradd -m -p $(openssl passwd -crypt $userpass) -s /bin/bash $user
+    useradd -m -p $(openssl passwd -5 $userpass) -s /bin/bash $user
     usermod -a -G $groupstr $user
   fi
 done < "$1"

--- a/rstudio/utils/users.csv.template
+++ b/rstudio/utils/users.csv.template
@@ -1,3 +1,2 @@
-tyu,csbcpson,rstudio-user;rstudio-admin
-jeddy,csbcpson,rstudio-user;rstudio-admin
-student,csbcpson,rstudio-user
+admin,changeme,rstudio-user;rstudio-admin
+student,changeme,rstudio-user


### PR DESCRIPTION
Resolves #31 . 

Additionally, `tidyverse:4.2.2` comes with openssl v3.1.1, so an update to the `openssl` command in the `add_users.sh` script was also required. Specifically: `-crypt` was removed in v3.0 (according to the [migration guide](https://www.openssl.org/docs/man3.0/man7/migration_guide.html)); I decided to encrypt with SHA256 as replacement.